### PR TITLE
修复了compose集群定义中stamp模块未依赖mysql的问题

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,3 +14,5 @@ services:
       ./stampmarket-stamp
     ports:
       - 9002:9002
+    depends_on:
+      - mysql


### PR DESCRIPTION
如题所述，修复了compose集群定义中stamp模块未依赖mysql的问题